### PR TITLE
Add resource directory to the constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ Now check the examples folder! :) Great right? You now have 2 files, `hello_worl
 
 Check the *API* of the  `compile` and `process` functions in the file `src/JasperPHP/JasperPHP.php` file.
 
+####Listing Parameters
+
+Querying the jasper file to examine parameters available in the given jasper report file:
+
+	$output = JasperPHP::list_parameters(
+			base_path() . '/vendor/cossou/jasperphp/examples/hello_world.jasper'
+		)->execute();
+	
+	foreach($output as $parameter_description) {
+		echo $parameter_description;
+	}
+
 ###Advanced example
 
 TODO.

--- a/src/JasperPHP/JasperPHP.php
+++ b/src/JasperPHP/JasperPHP.php
@@ -126,6 +126,22 @@ class JasperPHP
 
         return $this;
     }
+    
+    public function list_parameters($input_file)
+    {
+        if(is_null($input_file) || empty($input_file))
+            throw new \Exception("No input file", 1);
+
+        $command = __DIR__ . $this->executable;
+
+        $command .= " lpa ";
+
+        $command .= $input_file;
+
+        $this->the_command = $command;
+
+        return $this;
+    }
 
     public function output()
     {

--- a/src/JasperPHP/JasperPHP.php
+++ b/src/JasperPHP/JasperPHP.php
@@ -9,11 +9,21 @@ class JasperPHP
     protected $background;
     protected $windows = false;
     protected $formats = array('pdf', 'rtf', 'xls', 'xlsx', 'docx', 'odt', 'ods', 'pptx', 'csv', 'html', 'xhtml', 'xml', 'jrprint');
+    protected $resource_directory; // Path to report resource dir or jar file
 
-    function __construct()
+    function __construct($resource_dir = false)
     {
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
            $this->windows = true;
+           
+        if (!$resource_dir) {
+            $this->resource_directory = __DIR__ . "/../../../../../";
+        }else {
+            if (!file_exists($resource_dir))
+                throw new \Exception("Invalid resource directory", 1);
+
+            $this->resource_directory = $resource_dir;
+        }
     }
 
     public static function __callStatic($method, $parameters)
@@ -78,7 +88,7 @@ class JasperPHP
             $command .= " -f " . $format;
 
         // Resources dir
-        $command .= " -r " . __DIR__ . "/../../../../../";
+        $command .= " -r " . $this->resource_directory;
 
         if( count($parameters) > 0 )
         {

--- a/src/JasperPHP/JasperPHP.php
+++ b/src/JasperPHP/JasperPHP.php
@@ -146,7 +146,7 @@ class JasperPHP
         $output     = array();
         $return_var = 0;
 
-        exec($this->the_command, $output, $return_var);
+        exec(escapeshellcmd($this->the_command), $output, $return_var);
 
         if($return_var != 0) 
             throw new \Exception("There was and error executing the report! Time to check the logs!", 1);


### PR DESCRIPTION
Specify the resource directory in the constructor. Some reports will have images embedded. The resource directory can point to the directory where the images reside.

This way we can separate the resources folder from within the composer third party installation folder (__DIR__ . "/../../../../../")