### PR TITLE
Allow define locale at constructor

### DIFF
--- a/src/JasperPHP/JasperPHP.php
+++ b/src/JasperPHP/JasperPHP.php
@@ -11,8 +11,8 @@ class JasperPHP
     protected $formats = array('pdf', 'rtf', 'xls', 'xlsx', 'docx', 'odt', 'ods', 'pptx', 'csv', 'html', 'xhtml', 'xml', 'jrprint');
     protected $resource_directory; // Path to report resource dir or jar file
 
-    function __construct($resource_dir = false)
-    {
+    function __construct($resource_dir = false, $locale = false)
+    {        
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
            $this->windows = true;
 
@@ -24,6 +24,9 @@ class JasperPHP
 
             $this->resource_directory = $resource_dir;
         }
+
+        if($locale)
+            $this->executable.=' --locale='.$locale;
     }
 
     public static function __callStatic($method, $parameters)


### PR DESCRIPTION
Hi. In Brazil, we have the format currency like R$ ###.###,##, using point to thousand separator and comma for decimals. For jasperstarter format my decimal, i need specify the locale. See at images, now working the format.

Wrong:
![image](https://cloud.githubusercontent.com/assets/2893078/19692705/a2256fd4-9ab7-11e6-9404-5a7291f67bca.png)


Right:
![image](https://cloud.githubusercontent.com/assets/2893078/19692611/566b60a8-9ab7-11e6-803a-55b32159cb2b.png)

Reference: http://jasperstarter.cenote.de/usage.html
