### PR TITLE
Fixes problems with PHP 7

### DIFF
--- a/src/JasperPHP/JasperPHP.php
+++ b/src/JasperPHP/JasperPHP.php
@@ -90,7 +90,7 @@ class JasperPHP
         // Resources dir
         $command .= " -r " . $this->resource_directory;
 
-        if( count($parameters) > 0 )
+        if( !empty($parameters) )
         {
             $command .= " -P";
             foreach ($parameters as $key => $value)


### PR DESCRIPTION
Avoids this errors that also causing not generate the result file.

Warning: count(): Parameter must be an array or an object that implements Countable in vendor/cossou/jasperphp/src/JasperPHP/JasperPHP.php on line 93

Warning: Invalid argument supplied for foreach() in vendor/cossou/jasperphp/src/JasperPHP/JasperPHP.php on line 96