### PR TITLE
Expose setter method for resource_directory

### DIFF
--- a/src/JasperPHP/JasperPHP.php
+++ b/src/JasperPHP/JasperPHP.php
@@ -192,4 +192,9 @@ class JasperPHP
 
         return $output;
     }
+    
+    public function setResourceDirectory($resourceDirectory) 
+    {
+        $this->resource_directory = $resourceDirectory;
+    }    
 }


### PR DESCRIPTION
Hi,
Let's suppose I want to instance JasperPHP once and produce two different reports using resources located in two separated directories.
At the moment I need two instances of JasperPHP, wouldn't it be better if I could choose dinamically where to look for resources? In this way I could instantiate this class only once.

The same idea could be applied to most of this class properties, but at the moment my real use case concerns resource directory.

Thanks